### PR TITLE
FIX Fehler beim Erzeugen neuer Seiten

### DIFF
--- a/PageInstaller.php
+++ b/PageInstaller.php
@@ -19,12 +19,12 @@ class PageInstaller extends AbstractAppInstaller
     {
         return $this->getPagePath($source_path) . DIRECTORY_SEPARATOR . $languageCode;
     }
-    
+
     protected function getPagePath($source_path)
     {
         return $source_path . DIRECTORY_SEPARATOR . $this::FOLDER_NAME_PAGES;
     }
-    
+
     /**
      * 
      * {@inheritDoc}
@@ -34,7 +34,7 @@ class PageInstaller extends AbstractAppInstaller
     {
         $pagesFile = [];
         // Ordner entsprechend momentaner Sprache bestimmen.
-        $dir = $this->getPagesPathWithLanguage($source_absolute_path, $this->getApp()->getDefaultLanguageCode());
+        $dir = $this->getPagesPathWithLanguage($source_absolute_path, $this->getDefaultLanguageCode());
         if (! $dir) {
             // Ist entsprechend der momentanen Sprache kein passender Ordner vorhanden, wird
             // nichts gemacht.
@@ -93,10 +93,10 @@ class PageInstaller extends AbstractAppInstaller
         foreach ($pagesCreate as $page) {
             try {
                 $this->getWorkbench()->getCMS()->createPage($page);
-                $pagesCreatedCounter++;
+                $pagesCreatedCounter ++;
             } catch (\Throwable $e) {
                 $this->getWorkbench()->getLogger()->logException($e);
-                $pagesCreatedErrorCounter++;
+                $pagesCreatedErrorCounter ++;
             }
         }
         if ($pagesCreatedCounter) {
@@ -112,10 +112,10 @@ class PageInstaller extends AbstractAppInstaller
         foreach ($pagesUpdate as $page) {
             try {
                 $this->getWorkbench()->getCMS()->updatePage($page);
-                $pagesUpdatedCounter++;
+                $pagesUpdatedCounter ++;
             } catch (\Throwable $e) {
                 $this->getWorkbench()->getLogger()->logException($e);
-                $pagesUpdatedErrorCounter++;
+                $pagesUpdatedErrorCounter ++;
             }
         }
         if ($pagesUpdatedCounter) {
@@ -131,10 +131,10 @@ class PageInstaller extends AbstractAppInstaller
         foreach ($pagesDelete as $page) {
             try {
                 $this->getWorkbench()->getCMS()->deletePage($page);
-                $pagesDeletedCounter++;
+                $pagesDeletedCounter ++;
             } catch (\Throwable $e) {
                 $this->getWorkbench()->getLogger()->logException($e);
-                $pagesDeletedErrorCounter++;
+                $pagesDeletedErrorCounter ++;
             }
         }
         if ($pagesDeletedCounter) {
@@ -213,11 +213,11 @@ class PageInstaller extends AbstractAppInstaller
                     // Hat die Seite einen Parent im inputArray dann wird sie erstmal ueber-
                     // sprungen. Sie wird erst im outputArray einsortiert, nachdem ihr Parent
                     // dort einsortiert wurde.
-                    $pagePos++;
+                    $pagePos ++;
                 }
                 // Alle Seiten im inputArray durchgehen.
             } while ($pagePos < count($inputPages));
-            $i++;
+            $i ++;
             // So oft wiederholen wie es Seiten im inputArray gibt oder die Abbruchbedingung
             // erfuellt ist (kreisfoermige Referenzen).
         } while (count($inputPages) > 0 && $i < count($pages));
@@ -229,6 +229,17 @@ class PageInstaller extends AbstractAppInstaller
         } else {
             return $sortedPages;
         }
+    }
+
+    protected function getDefaultLanguageCode()
+    {
+        $languageCode = $this->getApp()->getDefaultLanguageCode();
+        if (! $languageCode) {
+            $defaultLocale = $this->getWorkbench()->getConfig()->getOption("LOCALE.DEFAULT");
+            $languageCode = substr($defaultLocale, 0, strpos($defaultLocale, '_'));
+        }
+        
+        return $languageCode;
     }
 
     /**

--- a/PageInstaller.php
+++ b/PageInstaller.php
@@ -85,48 +85,63 @@ class PageInstaller extends AbstractAppInstaller
             }
         }
         
-        $pagesCreatedCounter = 0;
-        $pagesUpdatedCounter = 0;
-        $pagesDeletedCounter = 0;
         $result = '';
         
         // Pages erstellen.
+        $pagesCreatedCounter = 0;
+        $pagesCreatedErrorCounter = 0;
         foreach ($pagesCreate as $page) {
             try {
                 $this->getWorkbench()->getCMS()->createPage($page);
                 $pagesCreatedCounter++;
             } catch (\Throwable $e) {
                 $this->getWorkbench()->getLogger()->logException($e);
+                $pagesCreatedErrorCounter++;
             }
         }
         if ($pagesCreatedCounter) {
             $result .= ($result ? ', ' : '') . $pagesCreatedCounter . ' created';
         }
+        if ($pagesCreatedErrorCounter) {
+            $result .= ($result ? ', ' : '') . $pagesCreatedErrorCounter . ' create errors';
+        }
         
         // Pages aktualisieren.
+        $pagesUpdatedCounter = 0;
+        $pagesUpdatedErrorCounter = 0;
         foreach ($pagesUpdate as $page) {
             try {
                 $this->getWorkbench()->getCMS()->updatePage($page);
                 $pagesUpdatedCounter++;
             } catch (\Throwable $e) {
                 $this->getWorkbench()->getLogger()->logException($e);
+                $pagesUpdatedErrorCounter++;
             }
         }
         if ($pagesUpdatedCounter) {
             $result .= ($result ? ', ' : '') . $pagesUpdatedCounter . ' updated';
         }
+        if ($pagesUpdatedErrorCounter) {
+            $result .= ($result ? ', ' : '') . $pagesUpdatedErrorCounter . ' update errors';
+        }
         
         // Pages loeschen.
+        $pagesDeletedCounter = 0;
+        $pagesDeletedErrorCounter = 0;
         foreach ($pagesDelete as $page) {
             try {
                 $this->getWorkbench()->getCMS()->deletePage($page);
                 $pagesDeletedCounter++;
             } catch (\Throwable $e) {
                 $this->getWorkbench()->getLogger()->logException($e);
+                $pagesDeletedErrorCounter++;
             }
         }
         if ($pagesDeletedCounter) {
             $result .= ($result ? ', ' : '') . $pagesDeletedCounter . ' deleted';
+        }
+        if ($pagesDeletedErrorCounter) {
+            $result .= ($result ? ', ' : '') . $pagesDeletedErrorCounter . ' delete errors';
         }
         
         return $result ? 'Pages: ' . $result : '';

--- a/PageInstaller.php
+++ b/PageInstaller.php
@@ -41,8 +41,12 @@ class PageInstaller extends AbstractAppInstaller
         }
         // Pages aus Dateien laden.
         foreach (glob($dir . DIRECTORY_SEPARATOR . '*') as $file) {
+            $pageUxon = UxonObject::fromJson(file_get_contents($file));
             $page = UiPageFactory::create($this->getWorkbench()->ui(), '', null, $this->getApp()->getAliasWithNamespace());
-            $page->importUxonObject(UxonObject::fromJson(file_get_contents($file)));
+            // Der Inhalt der Seite darf nicht erzeugt werden, da verlinkte Seiten u.U. noch nicht
+            // vorhanden sind.
+            $page->importUxonObject($pageUxon, ['contents']);
+            $page->setContents($pageUxon->getProperty('contents'), false);
             // Wird eine Seite neu hinzugefuegt ist der parentDefaultAlias gleich dem
             // gesetzen parentAlias.
             $page->setMenuParentPageDefaultAlias($page->getMenuParentPageAlias());

--- a/PageInstaller.php
+++ b/PageInstaller.php
@@ -191,7 +191,7 @@ class PageInstaller extends AbstractAppInstaller
                 $parentFound = false;
                 // Hat die Seite einen Parent im inputArray?
                 foreach ($inputPages as $parentPagePos => $parentPage) {
-                    if (strcasecmp($parentAlias, $parentPage->getAliasWithNamespace()) == 0) {
+                    if ($parentPage->isExactly($parentAlias)) {
                         $parentFound = true;
                         break;
                     }
@@ -200,7 +200,7 @@ class PageInstaller extends AbstractAppInstaller
                     // Wenn die Seite keinen Parent im inputArray hat, hat sie einen im
                     // outputArray?
                     foreach ($sortedPages as $parentPagePos => $parentPage) {
-                        if (strcasecmp($parentAlias, $parentPage->getAliasWithNamespace()) == 0) {
+                        if ($parentPage->isExactly($parentAlias)) {
                             $parentFound = true;
                             break;
                         }

--- a/PageInstaller.php
+++ b/PageInstaller.php
@@ -41,12 +41,8 @@ class PageInstaller extends AbstractAppInstaller
         }
         // Pages aus Dateien laden.
         foreach (glob($dir . DIRECTORY_SEPARATOR . '*') as $file) {
-            $pageUxon = UxonObject::fromJson(file_get_contents($file));
             $page = UiPageFactory::create($this->getWorkbench()->ui(), '', null, $this->getApp()->getAliasWithNamespace());
-            // Der Inhalt der Seite darf nicht erzeugt werden, da verlinkte Seiten u.U. noch nicht
-            // vorhanden sind.
-            $page->importUxonObject($pageUxon, ['contents']);
-            $page->setContents($pageUxon->getProperty('contents'), false);
+            $page->importUxonObject(UxonObject::fromJson(file_get_contents($file)));
             // Wird eine Seite neu hinzugefuegt ist der parentDefaultAlias gleich dem
             // gesetzen parentAlias.
             $page->setMenuParentPageDefaultAlias($page->getMenuParentPageAlias());

--- a/PageInstaller.php
+++ b/PageInstaller.php
@@ -41,7 +41,7 @@ class PageInstaller extends AbstractAppInstaller
             return;
         }
         // Pages aus Dateien laden.
-        foreach (glob($dir . DIRECTORY_SEPARATOR . '*') as $file) {
+        foreach (glob($dir . DIRECTORY_SEPARATOR . '*.json') as $file) {
             $page = UiPageFactory::create($this->getWorkbench()->ui(), '', null, $this->getApp()->getAliasWithNamespace());
             $page->importUxonObject(UxonObject::fromJson(file_get_contents($file)));
             // Wird eine Seite neu hinzugefuegt ist der parentDefaultAlias gleich dem

--- a/PageInstaller.php
+++ b/PageInstaller.php
@@ -44,9 +44,9 @@ class PageInstaller extends AbstractAppInstaller
         foreach (glob($dir . DIRECTORY_SEPARATOR . '*.json') as $file) {
             $page = UiPageFactory::create($this->getWorkbench()->ui(), '', null, $this->getApp()->getAliasWithNamespace());
             $page->importUxonObject(UxonObject::fromJson(file_get_contents($file)));
-            // Wird eine Seite neu hinzugefuegt ist der parentDefaultAlias gleich dem
-            // gesetzen parentAlias.
-            $page->setMenuParentPageDefaultAlias($page->getMenuParentPageAlias());
+            // Wird eine Seite neu hinzugefuegt ist die menuDefaultPosition gleich der
+            // gesetzen Position.
+            $page->setMenuDefaultPosition($page->getMenuPosition());
             $pagesFile[] = $page;
         }
         $pagesFile = $this->sortPages($pagesFile);
@@ -63,9 +63,9 @@ class PageInstaller extends AbstractAppInstaller
             try {
                 $pageDb = $this->getWorkbench()->getCMS()->loadPageById($pageFile->getId(), true);
                 // Die Seite existiert bereits und wird aktualisiert.
-                if ($pageDb->exportUxonObject() != $pageFile->exportUxonObject() && $pageDb->isUpdateable()) {
-                    if ($pageDb->getMenuParentPageAlias() != $pageDb->getMenuParentPageDefaultAlias()) {
-                        // Die Seite wurde manuell umgehaengt. Der parentDefaultAlias wird
+                if (! $pageDb->equals($pageFile) && $pageDb->isUpdateable()) {
+                    if ($pageDb->isMoved()) {
+                        // Die Seite wurde manuell umgehaengt. Die menuDefaultPosition wird
                         // geupdated, die Position im Baum wird nicht geupdated.
                         $pageFile->setMenuIndex($pageDb->getMenuIndex());
                         $pageFile->setMenuParentPageAlias($pageDb->getMenuParentPageAlias());


### PR DESCRIPTION
Im PageInstaller wird der Seiteninhalt beim Erzeugen der Seite
nicht mehr geparst, da verlinkte Seiten u.U. noch nicht
existieren.