### PR TITLE
DEV InstallApp now logs install attempts

### DIFF
--- a/Actions/InstallApp.php
+++ b/Actions/InstallApp.php
@@ -8,7 +8,6 @@ use exface\Core\Factories\AppFactory;
 use exface\Core\Exceptions\DirectoryNotFoundError;
 use exface\Core\Exceptions\Actions\ActionInputInvalidObjectError;
 use exface\Core\CommonLogic\Constants\Icons;
-use exface\Core\Factories\WidgetFactory;
 use exface\Core\Interfaces\AppInterface;
 use exface\Core\Interfaces\Exceptions\ExceptionInterface;
 use exface\Core\CommonLogic\Selectors\AppSelector;
@@ -156,19 +155,38 @@ class InstallApp extends AbstractActionDeferred implements iCanBeCalledFromCLI, 
         
         $this->getWorkbench()->getCache()->clear();
     }
-    
+
+    /**
+     * Empties the output log of this instance and returns its reference.
+     * 
+     * @return array
+     */
     protected function resetOutputLog() : array
     {
         $this->outputLog = [];
         return $this->outputLog;
     }
-    
+
+    /**
+     * Store a string in the output log.
+     * 
+     * @param string $output
+     * @return string
+     */
     protected function logOutputLine(string $output) : string
     {
         $this->outputLog[] = $output;
         return $output;
     }
-    
+
+    /**
+     * Commits all lines in the output log to the database. Optionally, an exception may be passed to be saved alongside
+     * the previously logged lines.
+     * 
+     * @param AppSelectorInterface $appSelector
+     * @param \Throwable|null      $exception
+     * @return string
+     */
     protected function commitOutputLog(
         AppSelectorInterface $appSelector, 
         \Throwable $exception = null

--- a/Actions/InstallApp.php
+++ b/Actions/InstallApp.php
@@ -2,10 +2,14 @@
 namespace axenox\PackageManager\Actions;
 
 use exface\Core\CommonLogic\AbstractActionDeferred;
+use exface\Core\CommonLogic\Log\Processors\DebugWidgetProcessor;
+use exface\Core\DataTypes\MessageTypeDataType;
 use exface\Core\Factories\AppFactory;
 use exface\Core\Exceptions\DirectoryNotFoundError;
 use exface\Core\Exceptions\Actions\ActionInputInvalidObjectError;
 use exface\Core\CommonLogic\Constants\Icons;
+use exface\Core\Factories\WidgetFactory;
+use exface\Core\Interfaces\AppInterface;
 use exface\Core\Interfaces\Exceptions\ExceptionInterface;
 use exface\Core\CommonLogic\Selectors\AppSelector;
 use exface\Core\Interfaces\Selectors\AppSelectorInterface;
@@ -21,6 +25,7 @@ use exface\Core\Interfaces\Tasks\ResultMessageStreamInterface;
 use exface\Core\Interfaces\Actions\iModifyData;
 use exface\Core\Events\Installer\OnBeforeAppInstallEvent;
 use exface\Core\Events\Installer\OnAppInstallEvent;
+use exface\Core\Interfaces\WidgetInterface;
 
 /**
  * Installs/updates one or more apps including their meta model, custom installer, etc.
@@ -61,8 +66,30 @@ use exface\Core\Events\Installer\OnAppInstallEvent;
  */
 class InstallApp extends AbstractActionDeferred implements iCanBeCalledFromCLI, iModifyData
 {
-
+    private const COL_CLI_OUTPUT = 'CLI_OUTPUT';
+    private const COL_ERROR_LOG_ID = 'ERROR_LOG_ID';
+    private const COL_ERROR_MESSAGE = 'ERROR_MESSAGE';
+    private const COL_ERROR_DEBUG_WIDGET = 'ERROR_DEBUG_WIDGET';
+    private const COL_APP_OID = 'APP_OID';
+    private const COL_MESSAGE_TYPE = 'MESSAGE_TYPE';
+    
     private $target_app_aliases = [];
+    
+    protected array $outputLog = [];
+    
+    private DebugWidgetProcessor $debugWidgetProcessor;
+
+    public function __construct(AppInterface $app, WidgetInterface $trigger_widget = null)
+    {
+        parent::__construct($app, $trigger_widget);
+        
+        $this->debugWidgetProcessor = new DebugWidgetProcessor(
+            $this->getWorkbench(),
+            'sender',
+            'message'
+        );
+    }
+
 
     protected function init()
     {
@@ -89,31 +116,116 @@ class InstallApp extends AbstractActionDeferred implements iCanBeCalledFromCLI, 
     protected function performDeferred(array $aliases = []) : \Generator
     {
         $installed_counter = 0;
-        
+
         foreach ($aliases as $app_alias) {
-            yield  PHP_EOL . "Installing " . $app_alias . "..." . PHP_EOL;
+            $this->resetOutputLog();
             $app_selector = new AppSelector($this->getWorkbench(), $app_alias);
+            
+            yield $this->logOutputLine(PHP_EOL . "Installing " . $app_alias . "..." . PHP_EOL);
+
             try {
                 $installed_counter ++;
-                yield from $this->installApp($app_selector);
-                yield "..." . $app_alias . " successfully installed." . PHP_EOL;
+                foreach ($this->installApp($app_selector) as $result) {
+                    if(is_string($result)) {
+                        yield $this->logOutputLine($result);
+                    } else {
+                        yield $result;
+                    }
+                }
+                
+                yield $this->logOutputLine("..." . $app_alias . " successfully installed." . PHP_EOL);
+                yield $this->commitOutputLog($app_selector);
             } catch (\Exception $e) {
                 $installed_counter --;
                 $this->getWorkbench()->getLogger()->logException($e);
-                yield PHP_EOL . "ERROR: " . ($e instanceof ExceptionInterface ? $e->getMessage() . ' see log ID ' . $e->getId() : $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine()) . PHP_EOL;
-                yield "...{$app_alias} installation failed!" . PHP_EOL;
+
+                yield $this->logOutputLine(PHP_EOL . "ERROR: " . ($e instanceof ExceptionInterface ? 
+                        $e->getMessage() . ' see log ID ' . $e->getId() : 
+                        $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine()) . PHP_EOL
+                );
+                yield $this->logOutputLine("...{$app_alias} installation failed!" . PHP_EOL);
+                yield $this->commitOutputLog($app_selector, $e);
             }
         }
         
         if (count($aliases) == 0) {
-            yield 'No installable apps had been selected!';
+            yield $this->logOutputLine('No installable apps had been selected!');
         } elseif ($installed_counter == 0) {
-            yield  'No apps have been installed';
+            yield $this->logOutputLine('No apps have been installed');
         }
         
         $this->getWorkbench()->getCache()->clear();
     }
+    
+    protected function resetOutputLog() : array
+    {
+        $this->outputLog = [];
+        return $this->outputLog;
+    }
+    
+    protected function logOutputLine(string $output) : string
+    {
+        $this->outputLog[] = $output;
+        return $output;
+    }
+    
+    protected function commitOutputLog(
+        AppSelectorInterface $appSelector, 
+        \Throwable $exception = null
+    ) : string
+    {
+        if(empty($this->outputLog)) {
+            return '';
+        }
 
+        try {
+            $dataSheet = DataSheetFactory::createFromObjectIdOrAlias(
+                $this->getWorkbench(),
+                'axenox.PackageManager.APP_INSTALL_LOG'
+            );
+            
+            $cliOutput = '';
+            $errorText = '';
+            $errorLogId = null;
+            $debugWidget = null;
+            
+            // Get error data from exception, if possible.
+            if($exception !== null) {
+                $errorText = $exception->getMessage();
+                if($exception instanceof ExceptionInterface) {
+                    $errorLogId = $exception->getLogId();
+                    $debugWidget = call_user_func($this->debugWidgetProcessor, ['context' => ['sender' => $exception]]);
+                    $debugWidget = $debugWidget['message'];
+                }
+            } 
+            
+            foreach ($this->outputLog as $outputLine) {
+                $cliOutput .= $outputLine;
+                if($exception === null && str_starts_with(trim($outputLine), 'ERROR')) {
+                    $errorText .= $outputLine . (str_ends_with($outputLine, PHP_EOL) ? '' : PHP_EOL);
+                }
+            }
+
+
+            $dataSheet->addRow([
+                self::COL_CLI_OUTPUT => $cliOutput,
+                self::COL_ERROR_LOG_ID => $errorLogId,
+                self::COL_ERROR_MESSAGE => $errorText,
+                self::COL_ERROR_DEBUG_WIDGET => $debugWidget,
+                self::COL_APP_OID => AppFactory::create($appSelector)->getUid(),
+                self::COL_MESSAGE_TYPE => empty($errorText) ? MessageTypeDataType::SUCCESS : MessageTypeDataType::ERROR
+            ]);
+            
+            $dataSheet->dataCreate();
+        } catch (\Throwable $e) {
+            $this->getWorkbench()->getLogger()->logException($e);
+            $logId = $e instanceof ExceptionInterface ? ' See Log-ID ' . $e->getLogId() : '';
+            return PHP_EOL . 'WARNING: Could not save installation log! ' . $e->getMessage() . $logId . PHP_EOL;
+        }
+
+        return '';
+    }
+    
     /**
      * 
      * @param TaskInterface $task

--- a/Install/Sql/MySQL/Migrations/1.04/20260217_1144_01_NEW_exf_app_install_log
+++ b/Install/Sql/MySQL/Migrations/1.04/20260217_1144_01_NEW_exf_app_install_log
@@ -1,0 +1,17 @@
+-- UP
+CREATE TABLE `exf_app_install_log` (
+  `oid` binary(16) NOT NULL,
+  `created_on` datetime NOT NULL,
+  `modified_on` datetime NOT NULL,
+  `created_by_user_oid` binary(16) DEFAULT NULL,
+  `modified_by_user_oid` binary(16) DEFAULT NULL,
+  `error_log_id` varchar(30) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+  `error_message` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci,
+  `error_debug_widget` longtext CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci,
+  `cli_output` longtext CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci,
+  `app_oid` binary(16) DEFAULT NULL,
+  `message_type` varchar(20) NOT NULL,
+  PRIMARY KEY (`oid`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 ROW_FORMAT=DYNAMIC;
+
+-- DOWN

--- a/Model/99_PAGE/exface.core.app-installer-logs.json
+++ b/Model/99_PAGE/exface.core.app-installer-logs.json
@@ -1,0 +1,90 @@
+{
+    "uid": "0x11f1b7596516db0cb7599bc887268982",
+    "alias_with_namespace": "exface.core.app-installer-logs",
+    "menu_parent_page_selector": "0xb90bb0b8949f11e7a605028037ec0200",
+    "menu_index": 0,
+    "menu_visible": true,
+    "name": "App Installer Logs",
+    "description": "",
+    "intro": "",
+    "replaces_page_selector": null,
+    "created_by_user_selector": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+    "created_on": "2026-02-17 15:24:39",
+    "modified_by_user_selector": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+    "modified_on": "2026-02-19 15:03:38",
+    "contents": {
+        "object_alias": "axenox.PackageManager.APP_INSTALL_LOG",
+        "widget_type": "DataTable",
+        "sorters": [
+            {
+                "attribute_alias": "CREATED_ON",
+                "direction": "desc"
+            },
+            {
+                "attribute_alias": "CREATED_BY_USER",
+                "direction": "asc"
+            }
+        ],
+        "filters": [
+            {
+                "attribute_alias": "CREATED_BY_USER",
+                "caption": "User"
+            },
+            {
+                "attribute_alias": "CREATED_ON",
+                "caption": "Date"
+            },
+            {
+                "attribute_alias": "APP_OID",
+                "caption": "App"
+            },
+            {
+                "attribute_alias": "ERROR_LOG_ID"
+            },
+            {
+                "attribute_alias": "MESSAGE_TYPE"
+            }
+        ],
+        "columns": [
+            {
+                "attribute_alias": "MESSAGE_TYPE"
+            },
+            {
+                "attribute_alias": "CREATED_BY_USER__LABEL",
+                "caption": "User"
+            },
+            {
+                "attribute_alias": "CREATED_ON",
+                "caption": "Date"
+            },
+            {
+                "attribute_alias": "APP_OID__ALIAS",
+                "caption": "App"
+            },
+            {
+                "attribute_alias": "ERROR_LOG_ID"
+            },
+            {
+                "attribute_alias": "ERROR_MESSAGE"
+            },
+            {
+                "attribute_alias": "ERROR_DEBUG_WIDGET",
+                "hidden": true
+            }
+        ],
+        "buttons": [
+            {
+                "action_alias": "exface.core.ShowObjectEditDialog",
+                "caption": "Details",
+                "icon": "info-circle",
+                "bind_to_double_click": true
+            },
+            {
+                "action_alias": "axenox.PackageManager.ShowMonitorError"
+            },
+            {
+                "action_alias": "axenox.PackageManager.ShowMonitorErrorWidget"
+            }
+        ]
+    }
+}

--- a/Model/axenox.PackageManager.APP_INSTALL_LOG/02_OBJECT.json
+++ b/Model/axenox.PackageManager.APP_INSTALL_LOG/02_OBJECT.json
@@ -1,0 +1,241 @@
+{
+    "object_alias": "exface.Core.OBJECT",
+    "columns": [
+        {
+            "name": "_EXPORT_SUMMARY",
+            "hidden": true,
+            "attribute_alias": "LABEL"
+        },
+        {
+            "name": "CREATED_ON",
+            "attribute_alias": "CREATED_ON"
+        },
+        {
+            "name": "MODIFIED_ON",
+            "attribute_alias": "MODIFIED_ON"
+        },
+        {
+            "name": "CREATED_BY_USER",
+            "attribute_alias": "CREATED_BY_USER"
+        },
+        {
+            "name": "MODIFIED_BY_USER",
+            "attribute_alias": "MODIFIED_BY_USER"
+        },
+        {
+            "name": "UID",
+            "attribute_alias": "UID"
+        },
+        {
+            "name": "READABLE_FLAG",
+            "attribute_alias": "READABLE_FLAG"
+        },
+        {
+            "name": "WRITABLE_FLAG",
+            "attribute_alias": "WRITABLE_FLAG"
+        },
+        {
+            "name": "COMMENTS",
+            "attribute_alias": "COMMENTS"
+        },
+        {
+            "name": "DOCS",
+            "attribute_alias": "DOCS"
+        },
+        {
+            "name": "NAME",
+            "attribute_alias": "NAME"
+        },
+        {
+            "name": "INHERIT_DATA_SOURCE_BASE_OBJECT",
+            "attribute_alias": "INHERIT_DATA_SOURCE_BASE_OBJECT"
+        },
+        {
+            "name": "DATA_SOURCE",
+            "attribute_alias": "DATA_SOURCE"
+        },
+        {
+            "name": "APP",
+            "attribute_alias": "APP"
+        },
+        {
+            "name": "SHORT_DESCRIPTION",
+            "attribute_alias": "SHORT_DESCRIPTION"
+        },
+        {
+            "name": "PARENT_OBJECT",
+            "attribute_alias": "PARENT_OBJECT"
+        },
+        {
+            "name": "DATA_ADDRESS_PROPS",
+            "attribute_alias": "DATA_ADDRESS_PROPS"
+        },
+        {
+            "name": "DEFAULT_EDITOR_UXON",
+            "attribute_alias": "DEFAULT_EDITOR_UXON"
+        },
+        {
+            "name": "ALIAS",
+            "attribute_alias": "ALIAS"
+        },
+        {
+            "name": "DATA_ADDRESS",
+            "attribute_alias": "DATA_ADDRESS"
+        }
+    ],
+    "rows": [
+        {
+            "_EXPORT_SUMMARY": "App Install Log [axenox.PackageManager.APP_INSTALL_LOG]",
+            "CREATED_ON": "2026-02-17 16:03:42",
+            "MODIFIED_ON": "2026-02-18 18:15:51",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f1839ed964b1e6839eb58881de3bec",
+            "READABLE_FLAG": 1,
+            "WRITABLE_FLAG": 1,
+            "COMMENTS": "",
+            "DOCS": "",
+            "NAME": "App Install Log",
+            "INHERIT_DATA_SOURCE_BASE_OBJECT": 1,
+            "DATA_SOURCE": "0x32000000000000000000000000000000",
+            "APP": "0x31380000000000000000000000000000",
+            "SHORT_DESCRIPTION": "",
+            "PARENT_OBJECT": null,
+            "DATA_ADDRESS_PROPS": null,
+            "DEFAULT_EDITOR_UXON": {
+                "widget_type": "Dialog",
+                "object_alias": "axenox.PackageManager.APP_INSTALL_LOG",
+                "widgets": [
+                    {
+                        "widget_type": "Tabs",
+                        "tabs": [
+                            {
+                                "caption": "Output",
+                                "widgets": [
+                                    {
+                                        "caption": "Info",
+                                        "widget_type": "WidgetGroup",
+                                        "width": 2,
+                                        "readonly": true,
+                                        "widgets": [
+                                            {
+                                                "attribute_alias": "MESSAGE_TYPE"
+                                            },
+                                            {
+                                                "attribute_alias": "CREATED_BY_USER__LABEL",
+                                                "caption": "User"
+                                            },
+                                            {
+                                                "attribute_alias": "CREATED_ON"
+                                            },
+                                            {
+                                                "attribute_alias": "APP_OID__ALIAS",
+                                                "caption": "App"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "caption": "Output",
+                                        "widget_type": "WidgetGroup",
+                                        "width": 2,
+                                        "widgets": [
+                                            {
+                                                "attribute_alias": "CLI_OUTPUT",
+                                                "height": 20,
+                                                "width": "max",
+                                                "hide_caption": true,
+                                                "disabled": true
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "caption": "Error",
+                                "widgets": [
+                                    {
+                                        "caption": "Info",
+                                        "widget_type": "WidgetGroup",
+                                        "width": 2,
+                                        "readonly": true,
+                                        "widgets": [
+                                            {
+                                                "attribute_alias": "MESSAGE_TYPE"
+                                            },
+                                            {
+                                                "attribute_alias": "CREATED_BY_USER__LABEL",
+                                                "caption": "User"
+                                            },
+                                            {
+                                                "attribute_alias": "CREATED_ON"
+                                            },
+                                            {
+                                                "attribute_alias": "APP_OID__ALIAS",
+                                                "caption": "App"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "//": "This group is empty, because if we put the text widget in here, we get some weird rendering issues.",
+                                        "caption": "Error",
+                                        "widget_type": "WidgetGroup",
+                                        "width": 2
+                                    },
+                                    {
+                                        "attribute_alias": "ERROR_LOG_ID",
+                                        "caption": "Error-Log ID",
+                                        "widget_type": "Text"
+                                    },
+                                    {
+                                        "attribute_alias": "ERROR_MESSAGE",
+                                        "height": 20,
+                                        "width": "max",
+                                        "hide_caption": true,
+                                        "disabled": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "buttons": [
+                    {
+                        "action_alias": "axenox.PackageManager.ShowMonitorError",
+                        "close_dialog": false
+                    },
+                    {
+                        "action_alias": "axenox.PackageManager.ShowMonitorErrorWidget",
+                        "close_dialog": false
+                    }
+                ]
+            },
+            "ALIAS": "APP_INSTALL_LOG",
+            "DATA_ADDRESS": "exf_app_install_log"
+        }
+    ],
+    "totals_rows": [],
+    "filters": {
+        "operator": "AND",
+        "base_object_alias": "exface.Core.OBJECT",
+        "conditions": [
+            {
+                "expression": "APP",
+                "comparator": "=",
+                "value": "0x31380000000000000000000000000000",
+                "object_alias": "exface.Core.OBJECT"
+            }
+        ]
+    },
+    "rows_limit": null,
+    "rows_offset": 0,
+    "sorters": [
+        {
+            "attribute_alias": "CREATED_ON",
+            "direction": "ASC"
+        },
+        {
+            "attribute_alias": "UID",
+            "direction": "ASC"
+        }
+    ]
+}

--- a/Model/axenox.PackageManager.APP_INSTALL_LOG/04_ATTRIBUTE.json
+++ b/Model/axenox.PackageManager.APP_INSTALL_LOG/04_ATTRIBUTE.json
@@ -1,0 +1,515 @@
+{
+    "object_alias": "exface.Core.ATTRIBUTE",
+    "columns": [
+        {
+            "name": "_EXPORT_SUMMARY",
+            "hidden": true,
+            "attribute_alias": "LABEL"
+        },
+        {
+            "name": "CREATED_ON",
+            "attribute_alias": "CREATED_ON"
+        },
+        {
+            "name": "MODIFIED_ON",
+            "attribute_alias": "MODIFIED_ON"
+        },
+        {
+            "name": "CREATED_BY_USER",
+            "attribute_alias": "CREATED_BY_USER"
+        },
+        {
+            "name": "MODIFIED_BY_USER",
+            "attribute_alias": "MODIFIED_BY_USER"
+        },
+        {
+            "name": "UID",
+            "attribute_alias": "UID"
+        },
+        {
+            "name": "SORTABLEFLAG",
+            "attribute_alias": "SORTABLEFLAG"
+        },
+        {
+            "name": "FILTERABLEFLAG",
+            "attribute_alias": "FILTERABLEFLAG"
+        },
+        {
+            "name": "AGGREGATABLEFLAG",
+            "attribute_alias": "AGGREGATABLEFLAG"
+        },
+        {
+            "name": "DEFAULT_AGGREGATE_FUNCTION",
+            "attribute_alias": "DEFAULT_AGGREGATE_FUNCTION"
+        },
+        {
+            "name": "VALUE_LIST_DELIMITER",
+            "attribute_alias": "VALUE_LIST_DELIMITER"
+        },
+        {
+            "name": "READABLEFLAG",
+            "attribute_alias": "READABLEFLAG"
+        },
+        {
+            "name": "WRITABLEFLAG",
+            "attribute_alias": "WRITABLEFLAG"
+        },
+        {
+            "name": "SYSTEMFLAG",
+            "attribute_alias": "SYSTEMFLAG"
+        },
+        {
+            "name": "DEFAULT_EDITOR_UXON",
+            "attribute_alias": "DEFAULT_EDITOR_UXON"
+        },
+        {
+            "name": "COPY_WITH_RELATED_OBJECT",
+            "attribute_alias": "COPY_WITH_RELATED_OBJECT"
+        },
+        {
+            "name": "DELETE_WITH_RELATED_OBJECT",
+            "attribute_alias": "DELETE_WITH_RELATED_OBJECT"
+        },
+        {
+            "name": "DEFAULT_DISPLAY_UXON",
+            "attribute_alias": "DEFAULT_DISPLAY_UXON"
+        },
+        {
+            "name": "COMMENTS",
+            "attribute_alias": "COMMENTS"
+        },
+        {
+            "name": "NAME",
+            "attribute_alias": "NAME"
+        },
+        {
+            "name": "RELATION_CARDINALITY",
+            "attribute_alias": "RELATION_CARDINALITY"
+        },
+        {
+            "name": "TYPE",
+            "attribute_alias": "TYPE"
+        },
+        {
+            "name": "COPYABLEFLAG",
+            "attribute_alias": "COPYABLEFLAG"
+        },
+        {
+            "name": "ICON",
+            "attribute_alias": "ICON"
+        },
+        {
+            "name": "ICON_SET",
+            "attribute_alias": "ICON_SET"
+        },
+        {
+            "name": "ABBREVIATION",
+            "attribute_alias": "ABBREVIATION"
+        },
+        {
+            "name": "ALIAS",
+            "attribute_alias": "ALIAS"
+        },
+        {
+            "name": "DATATYPE",
+            "attribute_alias": "DATATYPE"
+        },
+        {
+            "name": "DATA_ADDRESS",
+            "attribute_alias": "DATA_ADDRESS"
+        },
+        {
+            "name": "OBJECT",
+            "attribute_alias": "OBJECT"
+        },
+        {
+            "name": "FORMATTER",
+            "attribute_alias": "FORMATTER"
+        },
+        {
+            "name": "DISPLAYORDER",
+            "attribute_alias": "DISPLAYORDER"
+        },
+        {
+            "name": "LABELFLAG",
+            "attribute_alias": "LABELFLAG"
+        },
+        {
+            "name": "UIDFLAG",
+            "attribute_alias": "UIDFLAG"
+        },
+        {
+            "name": "HIDDENFLAG",
+            "attribute_alias": "HIDDENFLAG"
+        },
+        {
+            "name": "EDITABLEFLAG",
+            "attribute_alias": "EDITABLEFLAG"
+        },
+        {
+            "name": "REQUIREDFLAG",
+            "attribute_alias": "REQUIREDFLAG"
+        },
+        {
+            "name": "RELATED_OBJ",
+            "attribute_alias": "RELATED_OBJ"
+        },
+        {
+            "name": "SORTERPOS",
+            "attribute_alias": "SORTERPOS"
+        },
+        {
+            "name": "SORTERDIR",
+            "attribute_alias": "SORTERDIR"
+        },
+        {
+            "name": "RELATED_OBJ_ATTR",
+            "attribute_alias": "RELATED_OBJ_ATTR"
+        },
+        {
+            "name": "SHORT_DESCRIPTION",
+            "attribute_alias": "SHORT_DESCRIPTION"
+        },
+        {
+            "name": "DATA_ADDRESS_PROPS",
+            "attribute_alias": "DATA_ADDRESS_PROPS"
+        },
+        {
+            "name": "DEFAULT_VALUE",
+            "attribute_alias": "DEFAULT_VALUE"
+        },
+        {
+            "name": "FIXED_VALUE",
+            "attribute_alias": "FIXED_VALUE"
+        },
+        {
+            "name": "CUSTOM_DATA_TYPE",
+            "attribute_alias": "CUSTOM_DATA_TYPE"
+        }
+    ],
+    "rows": [
+        {
+            "_EXPORT_SUMMARY": "App oid [APP_OID]",
+            "CREATED_ON": "2026-02-17 16:04:10",
+            "MODIFIED_ON": "2026-02-17 16:17:00",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f199aeea4280ce99ae3b69fd03ae93",
+            "SORTABLEFLAG": 1,
+            "FILTERABLEFLAG": 1,
+            "AGGREGATABLEFLAG": 1,
+            "DEFAULT_AGGREGATE_FUNCTION": "",
+            "VALUE_LIST_DELIMITER": ",",
+            "READABLEFLAG": 1,
+            "WRITABLEFLAG": 1,
+            "SYSTEMFLAG": 0,
+            "DEFAULT_EDITOR_UXON": null,
+            "COPY_WITH_RELATED_OBJECT": 0,
+            "DELETE_WITH_RELATED_OBJECT": 0,
+            "DEFAULT_DISPLAY_UXON": null,
+            "COMMENTS": "",
+            "NAME": "App oid",
+            "RELATION_CARDINALITY": "",
+            "TYPE": "D",
+            "COPYABLEFLAG": 1,
+            "ICON": "",
+            "ICON_SET": "",
+            "ABBREVIATION": "",
+            "ALIAS": "APP_OID",
+            "DATATYPE": "0x11e8091315d97da6b5b5e4b318306b9a",
+            "DATA_ADDRESS": "app_oid",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "FORMATTER": "",
+            "DISPLAYORDER": null,
+            "LABELFLAG": 0,
+            "UIDFLAG": 0,
+            "HIDDENFLAG": 0,
+            "EDITABLEFLAG": 1,
+            "REQUIREDFLAG": 1,
+            "RELATED_OBJ": "0x35370000000000000000000000000000",
+            "SORTERPOS": null,
+            "SORTERDIR": "",
+            "RELATED_OBJ_ATTR": null,
+            "SHORT_DESCRIPTION": "",
+            "DATA_ADDRESS_PROPS": {
+                "SQL_DATA_TYPE": "binary"
+            },
+            "DEFAULT_VALUE": "",
+            "FIXED_VALUE": "",
+            "CUSTOM_DATA_TYPE": null
+        },
+        {
+            "_EXPORT_SUMMARY": "Cli output [CLI_OUTPUT]",
+            "CREATED_ON": "2026-02-17 16:04:10",
+            "MODIFIED_ON": "2026-02-17 16:05:36",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f19c03ea4269f49c0325833f6c7d5b",
+            "SORTABLEFLAG": 1,
+            "FILTERABLEFLAG": 1,
+            "AGGREGATABLEFLAG": 1,
+            "DEFAULT_AGGREGATE_FUNCTION": "",
+            "VALUE_LIST_DELIMITER": ",",
+            "READABLEFLAG": 1,
+            "WRITABLEFLAG": 1,
+            "SYSTEMFLAG": 0,
+            "DEFAULT_EDITOR_UXON": null,
+            "COPY_WITH_RELATED_OBJECT": 0,
+            "DELETE_WITH_RELATED_OBJECT": 0,
+            "DEFAULT_DISPLAY_UXON": null,
+            "COMMENTS": "",
+            "NAME": "Cli output",
+            "RELATION_CARDINALITY": "",
+            "TYPE": "D",
+            "COPYABLEFLAG": 1,
+            "ICON": "",
+            "ICON_SET": "",
+            "ABBREVIATION": "",
+            "ALIAS": "CLI_OUTPUT",
+            "DATATYPE": "0x31310000000000000000000000000000",
+            "DATA_ADDRESS": "cli_output",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "FORMATTER": "",
+            "DISPLAYORDER": null,
+            "LABELFLAG": 0,
+            "UIDFLAG": 0,
+            "HIDDENFLAG": 0,
+            "EDITABLEFLAG": 1,
+            "REQUIREDFLAG": 0,
+            "RELATED_OBJ": null,
+            "SORTERPOS": null,
+            "SORTERDIR": "",
+            "RELATED_OBJ_ATTR": null,
+            "SHORT_DESCRIPTION": "",
+            "DATA_ADDRESS_PROPS": null,
+            "DEFAULT_VALUE": "",
+            "FIXED_VALUE": "",
+            "CUSTOM_DATA_TYPE": {
+                "length_max": 4294967295
+            }
+        },
+        {
+            "_EXPORT_SUMMARY": "Error log id [ERROR_LOG_ID]",
+            "CREATED_ON": "2026-02-17 16:04:10",
+            "MODIFIED_ON": "2026-02-18 14:11:08",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f1b0a9ea423574b0a9737eadcb1428",
+            "SORTABLEFLAG": 1,
+            "FILTERABLEFLAG": 1,
+            "AGGREGATABLEFLAG": 1,
+            "DEFAULT_AGGREGATE_FUNCTION": "",
+            "VALUE_LIST_DELIMITER": ",",
+            "READABLEFLAG": 1,
+            "WRITABLEFLAG": 1,
+            "SYSTEMFLAG": 0,
+            "DEFAULT_EDITOR_UXON": null,
+            "COPY_WITH_RELATED_OBJECT": 0,
+            "DELETE_WITH_RELATED_OBJECT": 0,
+            "DEFAULT_DISPLAY_UXON": null,
+            "COMMENTS": "",
+            "NAME": "Error log id",
+            "RELATION_CARDINALITY": "",
+            "TYPE": "D",
+            "COPYABLEFLAG": 1,
+            "ICON": "",
+            "ICON_SET": "",
+            "ABBREVIATION": "",
+            "ALIAS": "ERROR_LOG_ID",
+            "DATATYPE": "0x30000000000000000000000000000000",
+            "DATA_ADDRESS": "error_log_id",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "FORMATTER": "",
+            "DISPLAYORDER": null,
+            "LABELFLAG": 0,
+            "UIDFLAG": 0,
+            "HIDDENFLAG": 0,
+            "EDITABLEFLAG": 1,
+            "REQUIREDFLAG": 0,
+            "RELATED_OBJ": "0x11eb90f04b00a9be90f08c04ba002958",
+            "SORTERPOS": null,
+            "SORTERDIR": "",
+            "RELATED_OBJ_ATTR": "0x11eb8c4481427db88c448c04ba002958",
+            "SHORT_DESCRIPTION": "",
+            "DATA_ADDRESS_PROPS": null,
+            "DEFAULT_VALUE": "",
+            "FIXED_VALUE": "",
+            "CUSTOM_DATA_TYPE": {
+                "length_max": 30
+            }
+        },
+        {
+            "_EXPORT_SUMMARY": "Error message [ERROR_MESSAGE]",
+            "CREATED_ON": "2026-02-17 16:04:10",
+            "MODIFIED_ON": "2026-02-17 16:05:57",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f1b848ea425338b848a96d0836cd77",
+            "SORTABLEFLAG": 1,
+            "FILTERABLEFLAG": 1,
+            "AGGREGATABLEFLAG": 1,
+            "DEFAULT_AGGREGATE_FUNCTION": "",
+            "VALUE_LIST_DELIMITER": ",",
+            "READABLEFLAG": 1,
+            "WRITABLEFLAG": 1,
+            "SYSTEMFLAG": 0,
+            "DEFAULT_EDITOR_UXON": null,
+            "COPY_WITH_RELATED_OBJECT": 0,
+            "DELETE_WITH_RELATED_OBJECT": 0,
+            "DEFAULT_DISPLAY_UXON": null,
+            "COMMENTS": "",
+            "NAME": "Error message",
+            "RELATION_CARDINALITY": "",
+            "TYPE": "D",
+            "COPYABLEFLAG": 1,
+            "ICON": "",
+            "ICON_SET": "",
+            "ABBREVIATION": "",
+            "ALIAS": "ERROR_MESSAGE",
+            "DATATYPE": "0x31310000000000000000000000000000",
+            "DATA_ADDRESS": "error_message",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "FORMATTER": "",
+            "DISPLAYORDER": null,
+            "LABELFLAG": 0,
+            "UIDFLAG": 0,
+            "HIDDENFLAG": 0,
+            "EDITABLEFLAG": 1,
+            "REQUIREDFLAG": 0,
+            "RELATED_OBJ": null,
+            "SORTERPOS": null,
+            "SORTERDIR": "",
+            "RELATED_OBJ_ATTR": null,
+            "SHORT_DESCRIPTION": "",
+            "DATA_ADDRESS_PROPS": null,
+            "DEFAULT_VALUE": "",
+            "FIXED_VALUE": "",
+            "CUSTOM_DATA_TYPE": {
+                "length_max": 65535
+            }
+        },
+        {
+            "_EXPORT_SUMMARY": "Status [MESSAGE_TYPE]",
+            "CREATED_ON": "2026-02-17 16:17:40",
+            "MODIFIED_ON": "2026-02-17 16:17:40",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f1b829cceaea46b829e1d06d058bf2",
+            "SORTABLEFLAG": 1,
+            "FILTERABLEFLAG": 1,
+            "AGGREGATABLEFLAG": 1,
+            "DEFAULT_AGGREGATE_FUNCTION": "",
+            "VALUE_LIST_DELIMITER": ",",
+            "READABLEFLAG": 1,
+            "WRITABLEFLAG": 1,
+            "SYSTEMFLAG": 0,
+            "DEFAULT_EDITOR_UXON": null,
+            "COPY_WITH_RELATED_OBJECT": 0,
+            "DELETE_WITH_RELATED_OBJECT": 0,
+            "DEFAULT_DISPLAY_UXON": null,
+            "COMMENTS": "",
+            "NAME": "Status",
+            "RELATION_CARDINALITY": "",
+            "TYPE": "D",
+            "COPYABLEFLAG": 1,
+            "ICON": "",
+            "ICON_SET": "",
+            "ABBREVIATION": "",
+            "ALIAS": "MESSAGE_TYPE",
+            "DATATYPE": "0x11e8ebf600b07e5287f10205857feb81",
+            "DATA_ADDRESS": "message_type",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "FORMATTER": "",
+            "DISPLAYORDER": null,
+            "LABELFLAG": 0,
+            "UIDFLAG": 0,
+            "HIDDENFLAG": 0,
+            "EDITABLEFLAG": 0,
+            "REQUIREDFLAG": 0,
+            "RELATED_OBJ": null,
+            "SORTERPOS": null,
+            "SORTERDIR": "",
+            "RELATED_OBJ_ATTR": null,
+            "SHORT_DESCRIPTION": "",
+            "DATA_ADDRESS_PROPS": null,
+            "DEFAULT_VALUE": "",
+            "FIXED_VALUE": "",
+            "CUSTOM_DATA_TYPE": null
+        },
+        {
+            "_EXPORT_SUMMARY": "Error Debug Widget [ERROR_DEBUG_WIDGET]",
+            "CREATED_ON": "2026-02-18 16:30:50",
+            "MODIFIED_ON": "2026-02-18 18:02:52",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f1a42dce2f0d9ea42d5782caf9b45d",
+            "SORTABLEFLAG": 1,
+            "FILTERABLEFLAG": 1,
+            "AGGREGATABLEFLAG": 1,
+            "DEFAULT_AGGREGATE_FUNCTION": "",
+            "VALUE_LIST_DELIMITER": ",",
+            "READABLEFLAG": 1,
+            "WRITABLEFLAG": 1,
+            "SYSTEMFLAG": 0,
+            "DEFAULT_EDITOR_UXON": null,
+            "COPY_WITH_RELATED_OBJECT": 0,
+            "DELETE_WITH_RELATED_OBJECT": 0,
+            "DEFAULT_DISPLAY_UXON": null,
+            "COMMENTS": "",
+            "NAME": "Error Debug Widget",
+            "RELATION_CARDINALITY": "",
+            "TYPE": "D",
+            "COPYABLEFLAG": 1,
+            "ICON": "",
+            "ICON_SET": "",
+            "ABBREVIATION": "",
+            "ALIAS": "ERROR_DEBUG_WIDGET",
+            "DATATYPE": "0x11e905162eeb6334b04c0205857feb80",
+            "DATA_ADDRESS": "error_debug_widget",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "FORMATTER": "",
+            "DISPLAYORDER": null,
+            "LABELFLAG": 0,
+            "UIDFLAG": 0,
+            "HIDDENFLAG": 0,
+            "EDITABLEFLAG": 0,
+            "REQUIREDFLAG": 0,
+            "RELATED_OBJ": null,
+            "SORTERPOS": null,
+            "SORTERDIR": "",
+            "RELATED_OBJ_ATTR": null,
+            "SHORT_DESCRIPTION": "",
+            "DATA_ADDRESS_PROPS": null,
+            "DEFAULT_VALUE": "",
+            "FIXED_VALUE": "",
+            "CUSTOM_DATA_TYPE": {
+                "length_max": 4294967295
+            }
+        }
+    ],
+    "totals_rows": [],
+    "filters": {
+        "operator": "AND",
+        "base_object_alias": "exface.Core.ATTRIBUTE",
+        "conditions": [
+            {
+                "expression": "OBJECT__APP",
+                "comparator": "=",
+                "value": "0x31380000000000000000000000000000",
+                "object_alias": "exface.Core.ATTRIBUTE"
+            }
+        ]
+    },
+    "rows_limit": null,
+    "rows_offset": 0,
+    "sorters": [
+        {
+            "attribute_alias": "CREATED_ON",
+            "direction": "ASC"
+        },
+        {
+            "attribute_alias": "UID",
+            "direction": "ASC"
+        }
+    ]
+}

--- a/Model/axenox.PackageManager.APP_INSTALL_LOG/08_OBJECT_ACTION.json
+++ b/Model/axenox.PackageManager.APP_INSTALL_LOG/08_OBJECT_ACTION.json
@@ -1,0 +1,171 @@
+{
+    "object_alias": "exface.Core.OBJECT_ACTION",
+    "columns": [
+        {
+            "name": "_EXPORT_SUMMARY",
+            "hidden": true,
+            "attribute_alias": "LABEL"
+        },
+        {
+            "name": "CREATED_ON",
+            "attribute_alias": "CREATED_ON"
+        },
+        {
+            "name": "MODIFIED_ON",
+            "attribute_alias": "MODIFIED_ON"
+        },
+        {
+            "name": "CREATED_BY_USER",
+            "attribute_alias": "CREATED_BY_USER"
+        },
+        {
+            "name": "MODIFIED_BY_USER",
+            "attribute_alias": "MODIFIED_BY_USER"
+        },
+        {
+            "name": "UID",
+            "attribute_alias": "UID"
+        },
+        {
+            "name": "OBJECT",
+            "attribute_alias": "OBJECT"
+        },
+        {
+            "name": "ACTION_PROTOTYPE",
+            "attribute_alias": "ACTION_PROTOTYPE"
+        },
+        {
+            "name": "ALIAS",
+            "attribute_alias": "ALIAS"
+        },
+        {
+            "name": "NAME",
+            "attribute_alias": "NAME"
+        },
+        {
+            "name": "SHORT_DESCRIPTION",
+            "attribute_alias": "SHORT_DESCRIPTION"
+        },
+        {
+            "name": "CONFIG_UXON",
+            "attribute_alias": "CONFIG_UXON"
+        },
+        {
+            "name": "APP",
+            "attribute_alias": "APP"
+        },
+        {
+            "name": "USE_IN_OBJECT_BASKET_FLAG",
+            "attribute_alias": "USE_IN_OBJECT_BASKET_FLAG"
+        },
+        {
+            "name": "DOCS",
+            "attribute_alias": "DOCS"
+        }
+    ],
+    "rows": [
+        {
+            "_EXPORT_SUMMARY": "App Install Log: Monitor Error Log [ShowMonitorError]",
+            "CREATED_ON": "2026-02-18 14:48:42",
+            "MODIFIED_ON": "2026-02-18 16:47:13",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f1bcdb894fd34cbcdbe519c92902c9",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "ACTION_PROTOTYPE": "exface/core/Actions/ShowObjectEditDialog.php",
+            "ALIAS": "ShowMonitorError",
+            "NAME": "Monitor Error Log",
+            "SHORT_DESCRIPTION": "Opens the associated monitor error log, if it exists and ERROR_LOG_ID is not null.",
+            "CONFIG_UXON": {
+                "icon": "newspaper-o",
+                "input_invalid_if": [
+                    {
+                        "error_text": "ERROR_LOG_ID cannot be null!",
+                        "operator": "AND",
+                        "conditions": [
+                            {
+                                "expression": "ERROR_LOG_ID",
+                                "comparator": "==",
+                                "value": "null"
+                            }
+                        ]
+                    }
+                ],
+                "alias": "exface.Core.ShowObjectEditDialog",
+                "object_alias": "exface.Core.MONITOR_ERROR",
+                "input_mapper": {
+                    "from_object_alias": "axenox.PackageManager.APP_INSTALL_LOG",
+                    "to_object_alias": "exface.Core.MONITOR_ERROR",
+                    "column_to_column_mappings": [
+                        {
+                            "from": "ERROR_LOG_ID__UID",
+                            "to": "UID"
+                        }
+                    ]
+                }
+            },
+            "APP": "0x31380000000000000000000000000000",
+            "USE_IN_OBJECT_BASKET_FLAG": 0,
+            "DOCS": ""
+        },
+        {
+            "_EXPORT_SUMMARY": "App Install Log: Error Widget [ShowMonitorErrorWidget]",
+            "CREATED_ON": "2026-02-18 14:55:45",
+            "MODIFIED_ON": "2026-02-18 18:01:51",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f18abb85dc52168abb6945f509d960",
+            "OBJECT": "0x11f1839ed964b1e6839eb58881de3bec",
+            "ACTION_PROTOTYPE": "exface/core/Actions/ShowDialogFromData.php",
+            "ALIAS": "ShowMonitorErrorWidget",
+            "NAME": "Error Widget",
+            "SHORT_DESCRIPTION": "Renders the error widget if it is not null.",
+            "CONFIG_UXON": {
+                "object_alias": "axenox.PackageManager.APP_INSTALL_LOG",
+                "icon": "bug",
+                "uxon_attribute": "ERROR_DEBUG_WIDGET",
+                "input_invalid_if": [
+                    {
+                        "error_text": "ERROR_DEBUG_WIDGET cannot be null!",
+                        "operator": "AND",
+                        "conditions": [
+                            {
+                                "expression": "ERROR_DEBUG_WIDGET",
+                                "comparator": "==",
+                                "value": "null"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "APP": "0x31380000000000000000000000000000",
+            "USE_IN_OBJECT_BASKET_FLAG": 0,
+            "DOCS": ""
+        }
+    ],
+    "totals_rows": [],
+    "filters": {
+        "operator": "AND",
+        "base_object_alias": "exface.Core.OBJECT_ACTION",
+        "conditions": [
+            {
+                "expression": "APP",
+                "comparator": "=",
+                "value": "0x31380000000000000000000000000000",
+                "object_alias": "exface.Core.OBJECT_ACTION"
+            }
+        ]
+    },
+    "rows_limit": null,
+    "rows_offset": 0,
+    "sorters": [
+        {
+            "attribute_alias": "CREATED_ON",
+            "direction": "ASC"
+        },
+        {
+            "attribute_alias": "UID",
+            "direction": "ASC"
+        }
+    ]
+}

--- a/Model/exface.Core.APP/08_OBJECT_ACTION.json
+++ b/Model/exface.Core.APP/08_OBJECT_ACTION.json
@@ -525,6 +525,104 @@
             "APP": "0x31380000000000000000000000000000",
             "USE_IN_OBJECT_BASKET_FLAG": 0,
             "DOCS": ""
+        },
+        {
+            "_EXPORT_SUMMARY": "App: Show Installer Logs [ShowInstallLogs]",
+            "CREATED_ON": "2026-02-23 11:28:08",
+            "MODIFIED_ON": "2026-02-23 11:28:59",
+            "CREATED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "UID": "0x11f1bd1058d8269ebd1091e92a017802",
+            "OBJECT": "0x35370000000000000000000000000000",
+            "ACTION_PROTOTYPE": "exface/core/Actions/ShowDialog.php",
+            "ALIAS": "ShowInstallLogs",
+            "NAME": "Show Installer Logs",
+            "SHORT_DESCRIPTION": "",
+            "CONFIG_UXON": {
+                "icon": "info-circle",
+                "dialog": {
+                    "widgets": [
+                        {
+                            "object_alias": "axenox.PackageManager.APP_INSTALL_LOG",
+                            "widget_type": "DataTable",
+                            "sorters": [
+                                {
+                                    "attribute_alias": "CREATED_ON",
+                                    "direction": "desc"
+                                },
+                                {
+                                    "attribute_alias": "CREATED_BY_USER",
+                                    "direction": "asc"
+                                }
+                            ],
+                            "filters": [
+                                {
+                                    "attribute_alias": "CREATED_BY_USER",
+                                    "caption": "User"
+                                },
+                                {
+                                    "attribute_alias": "CREATED_ON",
+                                    "caption": "Date"
+                                },
+                                {
+                                    "attribute_alias": "APP_OID",
+                                    "caption": "App"
+                                },
+                                {
+                                    "attribute_alias": "ERROR_LOG_ID"
+                                },
+                                {
+                                    "attribute_alias": "MESSAGE_TYPE"
+                                }
+                            ],
+                            "columns": [
+                                {
+                                    "attribute_alias": "MESSAGE_TYPE"
+                                },
+                                {
+                                    "attribute_alias": "CREATED_BY_USER__LABEL",
+                                    "caption": "User"
+                                },
+                                {
+                                    "attribute_alias": "CREATED_ON",
+                                    "caption": "Date"
+                                },
+                                {
+                                    "attribute_alias": "APP_OID__ALIAS",
+                                    "caption": "App"
+                                },
+                                {
+                                    "attribute_alias": "ERROR_LOG_ID"
+                                },
+                                {
+                                    "attribute_alias": "ERROR_MESSAGE"
+                                },
+                                {
+                                    "attribute_alias": "ERROR_DEBUG_WIDGET",
+                                    "hidden": true
+                                }
+                            ],
+                            "buttons": [
+                                {
+                                    "action_alias": "exface.core.ShowObjectEditDialog",
+                                    "caption": "Details",
+                                    "icon": "info-circle",
+                                    "bind_to_double_click": true
+                                },
+                                {
+                                    "action_alias": "axenox.PackageManager.ShowMonitorError"
+                                },
+                                {
+                                    "action_alias": "axenox.PackageManager.ShowMonitorErrorWidget"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "APP": "0x31380000000000000000000000000000",
+            "USE_IN_OBJECT_BASKET_FLAG": 0,
+            "DOCS": ""
         }
     ],
     "totals_rows": [],


### PR DESCRIPTION
### Known Issues
- When opening debug widgets directly from the `App Installer Logs` page, the header will appear jumbled.
- Installer logs cannot link to migration logs yet.